### PR TITLE
feat(catalog-service): PostgreSQL ve JPA yapılandırması eklendi

### DIFF
--- a/catalog-service/pom.xml
+++ b/catalog-service/pom.xml
@@ -33,6 +33,16 @@
 	<dependencies>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-data-jpa</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.postgresql</groupId>
+			<artifactId>postgresql</artifactId>
+			<scope>runtime</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-actuator</artifactId>
 		</dependency>
 		<dependency>
@@ -43,7 +53,21 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-webmvc</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>org.flywaydb</groupId>
+			<artifactId>flyway-core</artifactId>
+		</dependency>
 
+		<dependency>
+			<groupId>org.flywaydb</groupId>
+			<artifactId>flyway-database-postgresql</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-devtools</artifactId>
+			<scope>runtime</scope>
+			<optional>true</optional>
+		</dependency>
 		<dependency>
 			<groupId>io.micrometer</groupId>
 			<artifactId>micrometer-registry-prometheus</artifactId>

--- a/catalog-service/src/main/resources/application.properties
+++ b/catalog-service/src/main/resources/application.properties
@@ -1,1 +1,16 @@
 spring.application.name=catalog-service
+server.port=8081
+server.shutdown=graceful
+
+#Postgres
+spring.datasource.url=jdbc:postgresql://localhost:5432/catalogdb
+spring.datasource.username=${DB_USERNAME:postgres}
+spring.datasource.password=${DB_PASSWORD:1234}
+spring.datasource.driver-class-name=org.postgresql.Driver
+
+
+#JPA
+spring.jpa.database-platform=org.hibernate.dialect.PostgreSQLDialect
+spring.jpa.hibernate.ddl-auto=validate
+spring.jpa.show-sql=true
+spring.jpa.properties.hibernate.format_sql=true


### PR DESCRIPTION
Katalog servisi için PostgreSQL veritabanı bağlantısı ve JPA desteği eklendi.

- application.properties:
  - Sunucu portu ve zarif kapatma ayarları eklendi.
  - PostgreSQL veritabanı bağlantı detayları yapılandırıldı.
  - JPA için Hibernate PostgreSQL lehçesi ve şema doğrulama ayarları yapıldı.
- pom.xml:
  - Spring Data JPA ve PostgreSQL JDBC sürücüsü bağımlılıkları eklendi.
  - Veritabanı migrasyonları için Flyway bağımlılıkları eklendi.
  - Geliştirme kolaylığı için Spring Boot DevTools eklendi. Closes #3