### PR TITLE
feat: Katalog servisi altyapısı ve CI/CD entegrasyonu (catalog-infra)

### DIFF
--- a/.github/workflows/catalog-service.yml
+++ b/.github/workflows/catalog-service.yml
@@ -1,0 +1,30 @@
+name: Catalog Service
+
+on:
+  push:
+    paths:
+      - catalog-service/**
+    branches:
+      - '**'
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    env:
+      working-directory: ./catalog-service
+    defaults:
+      run:
+        working-directory: ${{ env.working-directory }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Java 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+          cache: 'maven'
+
+      - name: Build with Maven
+        run: ./mvnw -ntp verify

--- a/catalog-service/pom.xml
+++ b/catalog-service/pom.xml
@@ -130,6 +130,13 @@
 			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
+				<executions>
+					<execution>
+						<goals>
+							<goal>build-info</goal>
+						</goals>
+					</execution>
+				</executions>
 			</plugin>
 			<plugin>
 			<groupId>io.github.git-commit-id</groupId>

--- a/catalog-service/src/main/resources/application.properties
+++ b/catalog-service/src/main/resources/application.properties
@@ -2,10 +2,14 @@ spring.application.name=catalog-service
 server.port=8081
 server.shutdown=graceful
 
+management.endpoints.web.exposure.include=*
+management.info.env.enabled=true
+management.info.git.mode=full
+management.info.build.enabled=true
 #Postgres
-spring.datasource.url=jdbc:postgresql://localhost:5432/catalogdb
-spring.datasource.username=${DB_USERNAME:postgres}
-spring.datasource.password=${DB_PASSWORD:1234}
+spring.datasource.url=jdbc:postgresql://localhost:15432/postgres
+spring.datasource.username=postgres
+spring.datasource.password=postgres
 spring.datasource.driver-class-name=org.postgresql.Driver
 
 

--- a/deployment/docker-compose/infra.yml
+++ b/deployment/docker-compose/infra.yml
@@ -1,0 +1,21 @@
+version: "3.8"
+name: 'bookstore-microservices'
+services:
+  catalog-db:
+    image: postgres:16-alpine
+    container_name: catalog-db
+    environment:
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD=postgres
+      - POSTGRES_DB=postgres
+    ports:
+      - "15432:5432"
+    healthcheck:
+      test: [ "CMD-SHELL", "pg_isready -U postgres" ]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    deploy:
+      resources:
+        limits:
+          memory: 500m


### PR DESCRIPTION
Bu taahhüt, katalog servisi için temel altyapı bileşenlerini ve sürekli entegrasyon (CI) iş akışını ekler.

- Yeni bir Docker Compose dosyası (infra.yml) eklendi. Bu dosya, katalog servisi için PostgreSQL veritabanını ayağa kaldırır ve yapılandırır. Veritabanı bağlantı detayları güncellendi.
- Katalog servisine Spring Boot Actuator bilgi uç noktaları (info) eklendi. Bu sayede uygulama hakkında derleme, ortam ve git bilgileri erişilebilir hale geldi.
- `spring-boot-maven-plugin` için `build-info` hedefi etkinleştirildi.
- GitHub Actions için katalog servisine özel bir CI iş akışı (workflow) eklendi. Bu iş akışı, servisin derlenmesini ve test edilmesini sağlar. Closes #5